### PR TITLE
Rename `getInitialState()` as `getState()`

### DIFF
--- a/app/src/main/java/com/chatty/android/chattyClient/module/StateManagerWrapper.java
+++ b/app/src/main/java/com/chatty/android/chattyClient/module/StateManagerWrapper.java
@@ -26,7 +26,7 @@ public class StateManagerWrapper {
     System.out.println(STATE_MANAGER_WRAPPER + " " + className + " " + state);
   }
 
-  public static State getInitialState() {
+  public static State getState() {
     return StateManagerWrapper.stateManager.getState();
   }
 }

--- a/app/src/main/java/com/chatty/android/chattyClient/presenter/main/MainPresenter.java
+++ b/app/src/main/java/com/chatty/android/chattyClient/presenter/main/MainPresenter.java
@@ -22,7 +22,7 @@ public class MainPresenter {
 
   public void construct() {
     StateManagerWrapper.subscribe(this::stateListener);
-    ArrayList<TimelineEntry> timeline = StateManagerWrapper.getInitialState().getTimeline();
+    ArrayList<TimelineEntry> timeline = StateManagerWrapper.getState().getTimeline();
 
     this.view.render(
       this::handleClickWriteButton,
@@ -48,7 +48,6 @@ public class MainPresenter {
     StateManagerWrapper.log(this.getClass().getSimpleName(), state);
 
     ArrayList<TimelineEntry> timeline = state.getTimeline();
-    System.out.println("12123123" + timeline);
 
     this.view.render(
       this::handleClickWriteButton,

--- a/app/src/main/java/com/chatty/android/chattyClient/view/main/MainActivity.java
+++ b/app/src/main/java/com/chatty/android/chattyClient/view/main/MainActivity.java
@@ -62,7 +62,6 @@ public class MainActivity extends AppCompatActivity {
     View.OnClickListener handleClickWriteButton,
     ArrayList<TimelineEntry> timeline
   ) {
-    System.out.println("render 2nd");
     renderWriteButton(handleClickWriteButton);
     renderTimeLineView(timeline);
     renderMainHeader();


### PR DESCRIPTION
- StateManagerWrapper's use of getInitialState() does only give birth to
confusion. Names are going to be the same, `getState()`.

Fixes https://github.com/chatty-app/chatty-app/issues/41