### PR TITLE
Create Renderer that facilitates cached rendering

### DIFF
--- a/app/src/main/java/com/chatty/android/chattyClient/externalModules/Renderer/Renderer.java
+++ b/app/src/main/java/com/chatty/android/chattyClient/externalModules/Renderer/Renderer.java
@@ -1,0 +1,40 @@
+package com.chatty.android.chattyClient.externalModules.Renderer;
+
+import java.util.HashMap;
+import java.util.List;
+
+public class Renderer {
+  static HashMap<Object, List<Object>> instanceDataMap = new HashMap<>();
+
+  public static boolean render(
+    Object instance,
+    List<Object> data,
+    Updater ...updaters
+  ) {
+    boolean instanceIsFound = true;
+
+    if (data.size() != updaters.length) {
+      // "render() needs the same length of data and updaters"
+      return false;
+    }
+
+    List<Object> previousData = Renderer.instanceDataMap.get(instance);
+
+    if (previousData == null) {
+      Renderer.instanceDataMap.put(instance, data);
+      instanceIsFound = false;
+    }
+
+    for (int i = 0; i < data.size(); i++) {
+      if (!instanceIsFound || data.get(i) != previousData.get(i)) {
+        updaters[i].run(data.get(i));
+      }
+    }
+
+    return true;
+  }
+
+  public interface Updater {
+    void run(Object o);
+  }
+}

--- a/app/src/main/java/com/chatty/android/chattyClient/presenter/main/MainPresenter.java
+++ b/app/src/main/java/com/chatty/android/chattyClient/presenter/main/MainPresenter.java
@@ -49,10 +49,9 @@ public class MainPresenter {
 
     ArrayList<TimelineEntry> timeline = state.getTimeline();
 
-//    this.view.render(
-//      this::handleClickWriteButton,
-//      timeline
-//    );
+    this.view.render(
+      timeline
+    );
 
     return null;
   }

--- a/app/src/main/java/com/chatty/android/chattyClient/state/reducers/Reducers.java
+++ b/app/src/main/java/com/chatty/android/chattyClient/state/reducers/Reducers.java
@@ -10,20 +10,21 @@ import java.util.ArrayList;
 public class Reducers {
   private static final String REDUCERS = "REDUCERS";
 
-  public static Object reduce(Object state, Action action) {
-    System.out.println(REDUCERS + " " + state + action.getType());
+  public static Object reduce(Object _state, Action action) {
+    System.out.println(REDUCERS + " " + _state + action.getType());
 
-    State newState = ((State) state).clone();
+//    State newState = ((State) state).clone();
+    State state = (State) _state;
 
     switch (action.getType()) {
       case ActionType.REQUEST_GET_DIARIES_SUCCESS:
         @SuppressWarnings("unchecked")
         ArrayList<TimelineEntry> list = (ArrayList<TimelineEntry>) action.getPayload().get("timeline");
-        newState.setTimeline(list);
-        return newState;
+        state.setTimeline(list);
+        return state;
 
       default:
-        return newState;
+        return state;
     }
   }
 }

--- a/app/src/main/java/com/chatty/android/chattyClient/view/main/MainActivity.java
+++ b/app/src/main/java/com/chatty/android/chattyClient/view/main/MainActivity.java
@@ -10,6 +10,7 @@ import android.view.View;
 import android.widget.ImageButton;
 
 import com.chatty.android.chattyClient.R;
+import com.chatty.android.chattyClient.externalModules.Renderer.Renderer;
 import com.chatty.android.chattyClient.model.TimelineEntry;
 import com.chatty.android.chattyClient.presenter.main.MainPresenter;
 import com.chatty.android.chattyClient.presenter.main.TimelineRecyclerViewAdapter;
@@ -17,6 +18,7 @@ import com.chatty.android.chattyClient.view.calendar.CalendarActivity;
 import com.chatty.android.chattyClient.view.setting.SettingActivity;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 
 import butterknife.BindView;
 import butterknife.ButterKnife;
@@ -82,22 +84,21 @@ public class MainActivity extends AppCompatActivity {
   public void render(
     ArrayList<TimelineEntry> timeline
   ) {
-    renderWriteButton();
-    renderTimeLineView(timeline);
-    renderMainHeader();
+    Renderer.render(
+      this,
+      Arrays.asList(timeline),
+      this::renderTimeLineView);
   }
 
   private void renderMainHeader() {
-
   }
 
   private void renderTimeLineView(
-    ArrayList<TimelineEntry> timeline
+    Object timeline
   ) {
-    this.recyclerViewAdapter.update(timeline);
+    this.recyclerViewAdapter.update((ArrayList<TimelineEntry>) timeline);
   }
 
   private void renderWriteButton() {
-
   }
 }


### PR DESCRIPTION
- Activity instance as key helps find the previous data injected to render
the view.
- One-size of cache helps avoid unnecessary re-rendering of views.

Fixes https://github.com/chatty-app/chatty-app/issues/39