### PR TITLE
Remove `presenterDidMount()` out of ExtendedPresenter

### DIFF
--- a/app/src/main/java/com/chatty/android/chattyClient/externalModules/AndroidExtended/ExtendedPresenter.java
+++ b/app/src/main/java/com/chatty/android/chattyClient/externalModules/AndroidExtended/ExtendedPresenter.java
@@ -5,6 +5,5 @@ import android.support.v7.app.AppCompatActivity;
 import java.util.function.Function;
 
 public interface ExtendedPresenter<S> {
-  void presenterDidMount();
   Object stateListener(S state);
 }

--- a/app/src/main/java/com/chatty/android/chattyClient/presenter/addFriend/AddFriendPresenter.java
+++ b/app/src/main/java/com/chatty/android/chattyClient/presenter/addFriend/AddFriendPresenter.java
@@ -39,10 +39,6 @@ public class AddFriendPresenter implements ExtendedPresenter<State> {
     addFriendActivity.initialRender(props);
   }
 
-  @Override
-  public void presenterDidMount() {
-  }
-
   public Object stateListener(State state) {
     return null;
   }

--- a/app/src/main/java/com/chatty/android/chattyClient/presenter/calendar/CalendarPresenter.java
+++ b/app/src/main/java/com/chatty/android/chattyClient/presenter/calendar/CalendarPresenter.java
@@ -17,15 +17,6 @@ public class CalendarPresenter {
   public void construct() {
     StateManagerWrapper.subscribe(this::stateListener);
     view.render();
-    presenterDidMount();
-  }
-
-  private void presenterDidMount() {
-    try {
-//      TODO: 월 별 일기 쓴 데이터 가져오기
-    } catch (Exception e) {
-
-    }
   }
 
   private Object stateListener(State state) {

--- a/app/src/main/java/com/chatty/android/chattyClient/presenter/diaryDetail/DiaryDetailPresenter.java
+++ b/app/src/main/java/com/chatty/android/chattyClient/presenter/diaryDetail/DiaryDetailPresenter.java
@@ -27,10 +27,7 @@ public class DiaryDetailPresenter {
       .getDiaries();
 
     this.view.initialRender(props);
-    this.presenterDidMount();
-  }
 
-  private void presenterDidMount() {
     Intent intent = this.view.getIntent();
     int diaryId = intent.getIntExtra("diaryId", 0);
 

--- a/app/src/main/java/com/chatty/android/chattyClient/presenter/friendsList/FriendsListPresenter.java
+++ b/app/src/main/java/com/chatty/android/chattyClient/presenter/friendsList/FriendsListPresenter.java
@@ -14,12 +14,6 @@ public class FriendsListPresenter implements ExtendedPresenter<State> {
   public void construct() {
     StateManagerWrapper.subscribe(this::stateListener);
     view.render();
-    this.presenterDidMount();
-  }
-
-  @Override
-  public void presenterDidMount() {
-
   }
 
   @Override

--- a/app/src/main/java/com/chatty/android/chattyClient/presenter/friendsSetting/FriendsSettingPresenter.java
+++ b/app/src/main/java/com/chatty/android/chattyClient/presenter/friendsSetting/FriendsSettingPresenter.java
@@ -14,15 +14,8 @@ public class FriendsSettingPresenter implements ExtendedPresenter<State> {
 
   public FriendsSettingPresenter(FriendsSettingActivity view) {
     this.view = view;
-  }
-
-  public void construct() {
     StateManagerWrapper.subscribe(this::stateListener);
     view.render();
-    this.presenterDidMount();
-  }
-
-  public void presenterDidMount() {
     try {
       StateManagerWrapper.dispatch(PartnerAction.requestGetPartnerProfileDetail());
     } catch (Exception e) {

--- a/app/src/main/java/com/chatty/android/chattyClient/presenter/main/MainPresenter.java
+++ b/app/src/main/java/com/chatty/android/chattyClient/presenter/main/MainPresenter.java
@@ -22,9 +22,6 @@ public class MainPresenter implements ExtendedPresenter<State> {
   private MainActivity view;
   private MainPresenter(MainActivity view) {
     this.view = view;
-  }
-
-  public void construct() {
     StateManagerWrapper.subscribe(this::stateListener);
 
     MainActivityProps props = new MainActivityProps();
@@ -33,10 +30,6 @@ public class MainPresenter implements ExtendedPresenter<State> {
     props.handleClickTimelineEntry = this::handleClickTimelineEntry;
 
     this.view.initialRender(props);
-    presenterDidMount();
-  }
-
-  public void presenterDidMount() {
     try {
       StateManagerWrapper.dispatch(DiaryAction.requestGetDiaries());
     } catch (Exception e) {
@@ -77,7 +70,6 @@ public class MainPresenter implements ExtendedPresenter<State> {
 
   public static MainPresenter of(MainActivity activity) {
     MainPresenter presenter = new MainPresenter(activity);
-    presenter.construct();
     return presenter;
   }
 }

--- a/app/src/main/java/com/chatty/android/chattyClient/presenter/setting/SettingPresenter.java
+++ b/app/src/main/java/com/chatty/android/chattyClient/presenter/setting/SettingPresenter.java
@@ -10,17 +10,8 @@ public class SettingPresenter implements ExtendedPresenter<State> {
 
   public SettingPresenter(SettingActivity view) {
     this.view = view;
-  }
-
-  public void construct() {
     StateManagerWrapper.subscribe(this::stateListener);
     view.render();
-    this.presenterDidMount();
-  }
-
-  @Override
-  public void presenterDidMount() {
-
   }
 
   public Object stateListener(State state) {

--- a/app/src/main/java/com/chatty/android/chattyClient/view/friendsSetting/FriendsSettingActivity.java
+++ b/app/src/main/java/com/chatty/android/chattyClient/view/friendsSetting/FriendsSettingActivity.java
@@ -65,7 +65,6 @@ public class FriendsSettingActivity extends AppCompatActivity {
     this.setContentView(R.layout.activity_friends_setting);
     ButterKnife.bind(this);
     presenter = new FriendsSettingPresenter(this);
-    presenter.construct();
   }
 
   public void render() {

--- a/app/src/main/java/com/chatty/android/chattyClient/view/setting/SettingActivity.java
+++ b/app/src/main/java/com/chatty/android/chattyClient/view/setting/SettingActivity.java
@@ -48,7 +48,6 @@ public class SettingActivity extends AppCompatActivity {
     this.setContentView(R.layout.activity_setting);
     ButterKnife.bind(this);
     presenter = new SettingPresenter(this);
-    presenter.construct();
   }
 
   public void render() {


### PR DESCRIPTION
- Keeping two different lifecycle is prone to cause errors. The app will run
only with the Android's default lifecycle.

Fixes https://github.com/chatty-app/chatty-app/issues/68