### PR TITLE
feat: Empty input when sending the text in chat

### DIFF
--- a/app/src/main/java/com/chatty/android/chattyClient/presenter/write/WritePresenter.java
+++ b/app/src/main/java/com/chatty/android/chattyClient/presenter/write/WritePresenter.java
@@ -1,6 +1,11 @@
 package com.chatty.android.chattyClient.presenter.write;
 
+import android.app.Activity;
+import android.text.TextUtils;
+import android.util.Log;
 import android.view.View;
+import android.widget.EditText;
+import android.widget.Toast;
 
 import com.chatty.android.chattyClient.api.ChattyApiDefinition;
 import com.chatty.android.chattyClient.api.ChattyApi;
@@ -49,13 +54,15 @@ public class WritePresenter extends ExtendedPresenter<WriteActivityProps, WriteA
     return props;
   }
 
-  public void handleClickWriteSubmit(String text) {
-    try {
-      String writeDiaryId = StateManagerWrapper.getState().writeDiaryId;
-      StateManagerWrapper.dispatch(ChatAction.requestAppendChat(writeDiaryId, text));
-    } catch (Exception e) {
-      e.printStackTrace();
+  public void handleClickWriteSubmit(EditText editText) {
+    if (!TextUtils.isEmpty(editText.getText())) {
+      try {
+        String writeDiaryId = StateManagerWrapper.getState().writeDiaryId;
+        StateManagerWrapper.dispatch(ChatAction.requestAppendChat(writeDiaryId, editText.getText().toString()));
+        editText.setText(null);
+      } catch (Exception e) {
+        e.printStackTrace();
+      }
     }
   }
-
 }

--- a/app/src/main/java/com/chatty/android/chattyClient/view/write/WriteActivity.java
+++ b/app/src/main/java/com/chatty/android/chattyClient/view/write/WriteActivity.java
@@ -5,6 +5,7 @@ import android.support.v7.app.AppCompatActivity;
 import android.os.Bundle;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
+import android.util.Log;
 import android.widget.EditText;
 import android.widget.ImageButton;
 import android.widget.TextView;
@@ -45,7 +46,6 @@ public class WriteActivity extends AppCompatActivity implements ExtendedView<Wri
 
   @BindView(R.id.textView_timeline_title)
   public TextView timelineTitle;
-
 
   @Override
   protected void onCreate(Bundle savedInstanceState) {
@@ -91,9 +91,7 @@ public class WriteActivity extends AppCompatActivity implements ExtendedView<Wri
 
   private void renderWriteSubmitButton(WriteActivityProps writeActivityProps) {
     this.writeSubmitButton.setOnClickListener((__) -> {
-      writeActivityProps.handleClickWriteSubmitButton.accept(
-        writeInputEditText.getText().toString()
-      );
+      writeActivityProps.handleClickWriteSubmitButton.accept(this.writeInputEditText);
     });
   }
 

--- a/app/src/main/java/com/chatty/android/chattyClient/view/write/WriteActivityProps.java
+++ b/app/src/main/java/com/chatty/android/chattyClient/view/write/WriteActivityProps.java
@@ -2,6 +2,7 @@ package com.chatty.android.chattyClient.view.write;
 
 import android.support.v7.app.AppCompatActivity;
 import android.text.Editable;
+import android.widget.EditText;
 
 import com.chatty.android.chattyClient.externalModules.AndroidExtended.Props;
 import com.chatty.android.chattyClient.model.ChatBalloon;
@@ -16,5 +17,5 @@ import java.util.function.Consumer;
 public class WriteActivityProps extends Props {
   public String writeDiaryId = "";
   public List<ChatBalloon> chatBalloons = new ArrayList<>();
-  public Consumer<String> handleClickWriteSubmitButton;
+  public Consumer<EditText> handleClickWriteSubmitButton;
 }

--- a/app/src/main/res/layout/activity_write.xml
+++ b/app/src/main/res/layout/activity_write.xml
@@ -17,17 +17,17 @@
     layout="@layout/item_global_header"/>
   <android.support.v7.widget.RecyclerView
     android:id="@+id/recyclerView_dialogue"
-    android:layout_height="wrap_content"
+    android:layout_height="@dimen/match_constraint"
     android:layout_width="@dimen/match_constraint"
-    app:layout_constraintBottom_toTopOf="@+id/constraintLayout"
+    app:layout_constraintBottom_toTopOf="@id/chat_box_constraintLayout"
     app:layout_constraintEnd_toEndOf="parent"
     app:layout_constraintHorizontal_bias="0.0"
     app:layout_constraintStart_toStartOf="parent"
-    app:layout_constraintTop_toBottomOf="@+id/item_global_header"
+    app:layout_constraintTop_toBottomOf="@id/item_global_header"
     app:layout_constraintVertical_bias="0.0"/>
   <android.support.constraint.ConstraintLayout
     android:background="@color/gray1"
-    android:id="@+id/constraintLayout"
+    android:id="@+id/chat_box_constraintLayout"
     android:layout_height="55dp"
     android:layout_width="@dimen/match_constraint"
     app:layout_constraintBottom_toBottomOf="parent"


### PR DESCRIPTION
- `writeInputEditText`의 전송 후 내부 text를 제거한다.
- 입력한 글이 없을 경우에는 글을 보내지 못하게 한다.

:Fixes https://github.com/chatty-app/chatty-app/issues/92